### PR TITLE
Added struct type

### DIFF
--- a/crates/vino-transport/src/invocation.rs
+++ b/crates/vino-transport/src/invocation.rs
@@ -75,11 +75,13 @@ impl Invocation {
   }
 
   /// Get the seed associated with an invocation if it exists.
+  #[must_use]
   pub fn seed(&self) -> Option<u64> {
     self.inherent.map(|i| i.seed)
   }
 
   /// Get the timestamp associated with an invocation if it exists.
+  #[must_use]
   pub fn timestamp(&self) -> Option<u64> {
     self.inherent.map(|i| i.timestamp)
   }
@@ -99,6 +101,7 @@ impl Invocation {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 /// Data inherent to an invocation. Meant to be supplied by a runtime, not a user.
+#[must_use]
 pub struct InherentData {
   /// The seed to associate with an invocation.
   pub seed: u64,

--- a/crates/vino-transport/src/message_transport/transport_wrapper.rs
+++ b/crates/vino-transport/src/message_transport/transport_wrapper.rs
@@ -83,6 +83,7 @@ impl TransportWrapper {
   }
 }
 
+#[cfg(feature = "json")]
 impl std::fmt::Display for TransportWrapper {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "{}", self.as_json())

--- a/crates/vino-types/src/signatures.rs
+++ b/crates/vino-types/src/signatures.rs
@@ -146,11 +146,13 @@ pub enum TypeSignature {
     /// The type of the map's values.
     value: Box<TypeSignature>,
   },
-  /// A type representing a ProviderLink
+  /// A type representing a ProviderLink.
   Link {
-    /// The provider ID
+    /// The provider ID.
     provider: Option<String>,
   },
+  /// A JSON-like key/value map.
+  Struct,
 }
 #[derive(Debug)]
 /// Error returned when attempting to convert an invalid string into a [TypeSignature].

--- a/crates/vino-types/tests/interface-test.json
+++ b/crates/vino-types/tests/interface-test.json
@@ -85,6 +85,19 @@
           "type": "string"
         }
       }
+    },
+    "map": {
+      "name": "map",
+      "inputs": {
+        "input": {
+          "type": "struct"
+        }
+      },
+      "outputs": {
+        "output": {
+          "type": "struct"
+        }
+      }
     }
   }
 }

--- a/crates/vino-types/tests/serde.rs
+++ b/crates/vino-types/tests/serde.rs
@@ -36,7 +36,7 @@ fn test_deserialize2() -> Result<()> {
   Ok(())
 }
 
-#[test_env_log::test]
+#[test_log::test]
 fn test_serde_all() -> Result<()> {
   let types: Vec<TypeSignature> = vec![
     TypeSignature::Bool,


### PR DESCRIPTION
The `struct` type was added for widl-codegen purposes but wasn't included in vino-types for component typing. This PR adds `struct` as a first-class type.